### PR TITLE
serialize array

### DIFF
--- a/benchmarks/src/benchmark_serialization.cpp
+++ b/benchmarks/src/benchmark_serialization.cpp
@@ -279,7 +279,10 @@ int main() {
   constexpr int test_sz = 50'000;
   std::vector<User> test_data(test_sz);
   for(int i = 0; i < test_sz; ++i) test_data[i] = generate_random_user();
+  std::vector<std::vector<User>> in_array = {  test_data  };
+  // bench<std::vector<User>>(in_array); // currently not supported
+  bench_simpler_reflection<std::vector<User>>(in_array);
   bench<User>(test_data);
   bench_simpler_reflection<User>(test_data);
-  return 0;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Adds a benchmark component where you serialize an array (so the output is large). This is more realistic regarding the scenario where you care about performance. Note that we are using over **50 instructions per input byte**. That's quite a lot, evidently.

```
# volume: 24 bytes
# output volume: 24391952 bytes
# output volume per string: 24391952.0 bytes
# min output volume per string: 24391952 bytes
# max output volume per string: 24391952 bytes
# max length: 8 bytes
# number of inputs: 1
# serialization
experimental_json_builder::universal_formatter :  184.19 MB/s   0.00 Ms/s   3.06 GHz  16.61 c/b  52.39 i/b   3.15 i/c 
# volume: 15200000 bytes
# output volume: 24291952 bytes
# output volume per string: 485.8 bytes
# min output volume per string: 488 bytes
# max output volume per string: 484 bytes
# max length: 8 bytes
# number of inputs: 50000
# serialization
experimental_json_builder::to_json_string :  185.51 MB/s   0.38 Ms/s   3.19 GHz  17.17 c/b  59.23 i/b   3.45 i/c 
# volume: 15200000 bytes
# output volume: 24291952 bytes
# output volume per string: 485.8 bytes
# min output volume per string: 488 bytes
# max output volume per string: 484 bytes
# max length: 8 bytes
# number of inputs: 50000
# serialization
experimental_json_builder::universal_formatter :  191.30 MB/s   0.39 Ms/s   3.19 GHz  16.65 c/b  54.89 i/b   3.30 i/c 
```