### PR TITLE
fix: remove another instance where we copy

### DIFF
--- a/benchmarks/src/fast_json_serializer.hpp
+++ b/benchmarks/src/fast_json_serializer.hpp
@@ -244,7 +244,7 @@ template <typename S> consteval auto print_struct() {
 template <typename T> constexpr auto struct_to_tuple(T const &t) {
   return [:expand_all(std::meta::nonstatic_data_members_of(^T)
                       ):] >> [&]<auto... members> {
-    return std::make_tuple(t.[:members:]...);
+    return std::make_tuple(std::cref(t.[:members:])...);
   };
 }
 


### PR DESCRIPTION

The `struct_to_tuple` effectively creates a temporary copy of the struct, which means copying the strings in particular. Using references instead is better.

Numbers:

<img width="982" alt="Screenshot 2024-05-26 at 12 27 55 PM" src="https://github.com/simdjson/experimental_json_builder/assets/391987/31dcf5b4-672e-47ec-a493-c7aed43c647b">


This is still not what we would like. What we should try to do is to avoid the construction of a tuple *entirely* at runtime. I'll open an issue.
