### PR TITLE
reflect cpp does not build under LLVM 19, disable by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ CPMAddPackage("gh:nlohmann/json@3.10.5")
 CPMAddPackage(
   NAME reflect-cpp
   GITHUB_REPOSITORY getml/reflect-cpp
-  GIT_TAG main
+  GIT_TAG v0.13.0
 )
 
 # Optionally, specify the C++ compiler directly (here we use clang++)

--- a/benchmarks/src/CMakeLists.txt
+++ b/benchmarks/src/CMakeLists.txt
@@ -60,6 +60,8 @@ target_compile_options(SerializationTwitterBenchmark PRIVATE -freflection -stdli
 # Link sanitizers and libraries
 target_link_libraries(SerializationTwitterBenchmark PRIVATE nlohmann_json::nlohmann_json simdjson::simdjson )
 
+target_link_libraries(SerializationBenchmark PRIVATE simdjson-serial nlohmann_json::nlohmann_json simdjson::simdjson)
+
 # cpp-reflect may fail to build on LLVM 19 due to this issue
 # https://github.com/hanickadot/compile-time-regular-expressions/issues/307
 option(SIMDJSON_BENCH_CPP_REFLECT "include cpp reflect in the benchmarks" OFF)
@@ -67,12 +69,18 @@ if(SIMDJSON_BENCH_CPP_REFLECT)
   message(STATUS "Including reflect-cpp in the benchmarks.")
   add_library(benchmark_reflect_serialization_twitter STATIC benchmark_reflect_serialization_twitter.cpp)
   target_link_libraries(benchmark_reflect_serialization_twitter PRIVATE reflectcpp)
+
   target_link_libraries(SerializationTwitterBenchmark PRIVATE benchmark_reflect_serialization_twitter)
-  target_compile_definitions(benchmark_reflect_serialization_twitter PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
+  target_compile_definitions(SerializationTwitterBenchmark PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
+
+
+  add_library(benchmark_reflect_serialization STATIC benchmark_reflect_serialization_twitter.cpp)
+  target_link_libraries(benchmark_reflect_serialization PRIVATE reflectcpp)
+
+  target_link_libraries(SerializationBenchmark PRIVATE benchmark_reflect_serialization)
+  target_compile_definitions(SerializationBenchmark PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
 endif()
 
-
-target_link_libraries(SerializationBenchmark PRIVATE simdjson-serial nlohmann_json::nlohmann_json simdjson::simdjson)
 
 
 target_compile_definitions(SerializationTwitterBenchmark PRIVATE JSON_FILE="${CMAKE_CURRENT_SOURCE_DIR}/data/twitter.json")

--- a/benchmarks/src/CMakeLists.txt
+++ b/benchmarks/src/CMakeLists.txt
@@ -56,10 +56,22 @@ add_executable(SerializationTwitterBenchmark benchmark_serialization_twitter.cpp
 target_compile_options(SerializationBenchmark PRIVATE -freflection -stdlib=libc++ -std=c++26)
 target_compile_options(SerializationTwitterBenchmark PRIVATE -freflection -stdlib=libc++ -std=c++26)
 
-#find_package(CURL REQUIRED)
 
 # Link sanitizers and libraries
-target_link_libraries(SerializationTwitterBenchmark PRIVATE nlohmann_json::nlohmann_json simdjson::simdjson reflectcpp)
+target_link_libraries(SerializationTwitterBenchmark PRIVATE nlohmann_json::nlohmann_json simdjson::simdjson )
+
+# cpp-reflect may fail to build on LLVM 19 due to this issue
+# https://github.com/hanickadot/compile-time-regular-expressions/issues/307
+option(SIMDJSON_BENCH_CPP_REFLECT "include cpp reflect in the benchmarks" OFF)
+if(SIMDJSON_BENCH_CPP_REFLECT)
+  message(STATUS "Including reflect-cpp in the benchmarks.")
+  add_library(benchmark_reflect_serialization_twitter STATIC benchmark_reflect_serialization_twitter.cpp)
+  target_link_libraries(benchmark_reflect_serialization_twitter PRIVATE reflectcpp)
+  target_link_libraries(SerializationTwitterBenchmark PRIVATE benchmark_reflect_serialization_twitter)
+  target_compile_definitions(benchmark_reflect_serialization_twitter PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
+endif()
+
+
 target_link_libraries(SerializationBenchmark PRIVATE simdjson-serial nlohmann_json::nlohmann_json simdjson::simdjson)
 
 target_compile_definitions(SerializationTwitterBenchmark PRIVATE JSON_FILE="${CMAKE_CURRENT_SOURCE_DIR}/data/twitter.json")

--- a/benchmarks/src/benchmark_helper.hpp
+++ b/benchmarks/src/benchmark_helper.hpp
@@ -1,0 +1,50 @@
+#ifndef BENCHMARK_HELPER_HPP
+#define BENCHMARK_HELPER_HPP
+#include "event_counter.h"
+
+inline event_collector& get_collector() {
+  static event_collector collector;
+  return collector;
+}
+
+template <class function_type>
+event_aggregate bench(const function_type &function, size_t min_repeat = 10,
+                      size_t min_time_ns = 1000000000,
+                      size_t max_repeat = 100000) {
+ event_collector& collector = get_collector();
+  event_aggregate aggregate{};
+  size_t N = min_repeat;
+  if (N == 0) {
+    N = 1;
+  }
+  for (size_t i = 0; i < N; i++) {
+    std::atomic_thread_fence(std::memory_order_acquire);
+    collector.start();
+    function();
+    std::atomic_thread_fence(std::memory_order_release);
+    event_count allocate_count = collector.end();
+    aggregate << allocate_count;
+    if ((i + 1 == N) && (aggregate.total_elapsed_ns() < min_time_ns) &&
+        (N < max_repeat)) {
+      N *= 10;
+    }
+  }
+  return aggregate;
+}
+
+// Source of the 2 functions below:
+// https://github.com/simdutf/simdutf/blob/master/benchmarks/base64/benchmark_base64.cpp
+inline void pretty_print(size_t strings, size_t bytes, std::string name, event_aggregate agg) {
+  event_collector& collector = get_collector();
+  printf("%-60s : ", name.c_str());
+  printf(" %5.2f MB/s ", bytes * 1000 / agg.elapsed_ns());
+  printf(" %5.2f Ms/s ", strings * 1000 / agg.elapsed_ns());
+  if (collector.has_events()) {
+    printf(" %5.2f GHz ", agg.cycles() / agg.elapsed_ns());
+    printf(" %5.2f c/b ", agg.cycles() / bytes);
+    printf(" %5.2f i/b ", agg.instructions() / bytes);
+    printf(" %5.2f i/c ", agg.instructions() / agg.cycles());
+  }
+  printf("\n");
+}
+#endif

--- a/benchmarks/src/benchmark_reflect_serialization.cpp
+++ b/benchmarks/src/benchmark_reflect_serialization.cpp
@@ -1,0 +1,21 @@
+#include "benchmark_reflect_serialization.hpp"
+#include "benchmark_helper.hpp"
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+void bench_reflect_cpp(std::vector<User>& data) {
+  std::string output = rfl::json::write(data);
+  size_t output_volume = output.size();
+  printf("# output volume: %zu bytes\n", output_volume);
+
+  volatile size_t measured_volume = 0;
+  pretty_print(
+    1, output_volume, "bench_reflect_cpp",
+    bench([&data, &measured_volume, &output_volume] () {
+      std::string output = rfl::json::write(data);
+      measured_volume = output.size();
+      if(measured_volume != output_volume) { printf("mismatch\n"); }
+    })
+  );
+}

--- a/benchmarks/src/benchmark_reflect_serialization.hpp
+++ b/benchmarks/src/benchmark_reflect_serialization.hpp
@@ -1,0 +1,6 @@
+#ifndef BENCHMARK_REFLECT_SERIALIZATION_TWITTER_HPP
+#define BENCHMARK_REFLECT_SERIALIZATION_TWITTER_HPP
+
+#include "user_profile.hpp"
+void bench_reflect_cpp(std::vector<User>& data)
+#endif

--- a/benchmarks/src/benchmark_reflect_serialization_twitter.cpp
+++ b/benchmarks/src/benchmark_reflect_serialization_twitter.cpp
@@ -1,0 +1,20 @@
+#include "benchmark_reflect_serialization_twitter.hpp"
+#include "benchmark_helper.hpp"
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+void bench_reflect_cpp(TwitterData& data) {
+  std::string output = rfl::json::write(data);
+  size_t output_volume = output.size();
+  printf("# output volume: %zu bytes\n", output_volume);
+
+  volatile size_t measured_volume = 0;
+  pretty_print(
+    1, output_volume, "bench_reflect_cpp",
+    bench([&data, &measured_volume, &output_volume] () {
+      std::string output = rfl::json::write(data);
+      measured_volume = output.size();
+      if(measured_volume != output_volume) { printf("mismatch\n"); }
+    })
+  );
+}

--- a/benchmarks/src/benchmark_reflect_serialization_twitter.hpp
+++ b/benchmarks/src/benchmark_reflect_serialization_twitter.hpp
@@ -1,0 +1,6 @@
+#ifndef BENCHMARK_REFLECT_SERIALIZATION_TWITTER_HPP
+#define BENCHMARK_REFLECT_SERIALIZATION_TWITTER_HPP
+
+#include "twitter_data.hpp"
+void bench_reflect_cpp(TwitterData& data);
+#endif

--- a/benchmarks/src/benchmark_serialization.cpp
+++ b/benchmarks/src/benchmark_serialization.cpp
@@ -10,12 +10,12 @@
 #include <vector>
 #include <format>
 #include <atomic>
-#include <rfl.hpp>
-#include <rfl/json.hpp>
 #include "user_profile.hpp"
 #include "custom_serializer.h"
 #include "nlohmann_user_profile.hpp"
-
+#if SIMDJSON_BENCH_CPP_REFLECT
+#include "benchmark_reflect_serialization.hpp"
+#endif
 std::string generate_email(const std::string &name,
                            const std::string &company) {
   std::string email = name + "@" + company + ".com";
@@ -231,21 +231,6 @@ void bench_nlohmann(std::vector<User> &data) {
   );
 }
 
-void bench_reflect_cpp(std::vector<User>& data) {
-  std::string output = rfl::json::write(data);
-  size_t output_volume = output.size();
-  printf("# output volume: %zu bytes\n", output_volume);
-
-  volatile size_t measured_volume = 0;
-  pretty_print(
-    1, output_volume, "bench_reflect_cpp",
-    bench([&data, &measured_volume, &output_volume] () {
-      std::string output = rfl::json::write(data);
-      measured_volume = output.size();
-      if(measured_volume != output_volume) { printf("mismatch\n"); }
-    })
-  );
-}
 
 
 int main() {
@@ -257,7 +242,8 @@ int main() {
   bench_nlohmann(test_data);
   bench_custom(test_data);
   bench_fast_simpler(test_data);
+#if SIMDJSON_BENCH_CPP_REFLECT
   bench_reflect_cpp(test_data);
-
+#endif
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
It appears that reflect cpp does not build under LLVM 19 so it breaks the build. Disable it by default until the issue is resolved.

The relevant issue is 

https://github.com/hanickadot/compile-time-regular-expressions/issues/307

They have not yet released a fix: https://github.com/hanickadot/compile-time-regular-expressions/releases

Reflect-cpp is using version 3.8.1 from October 2023:

https://github.com/getml/reflect-cpp/commit/b2f515d0e5e0f73c44df490a01348cb17a96e84f