### PR TITLE
adding an example that uses extract

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(example2 PRIVATE simdjson::serialization simdjson::simdjso
 add_executable(example3 example3.cpp)
 target_link_libraries(example3 PRIVATE simdjson::serialization simdjson::simdjson)
 
-
+add_executable(example4 example4.cpp)
+target_link_libraries(example4 PRIVATE simdjson::serialization)

--- a/examples/example4.cpp
+++ b/examples/example4.cpp
@@ -1,0 +1,95 @@
+#include "simdjson/json_builder/json_builder.h"
+#include "simdjson/json_builder/string_builder.h"
+#include <cstdlib>
+#include <format>
+#include <iostream>
+#include <print>
+#include <string>
+#include <vector>
+#include <tuple>
+struct Z {
+  int x;
+};
+
+struct Y {
+  int g;
+  std::string h;
+  std::vector<int> i;
+  Z z;
+};
+
+struct X {
+  char a;
+  int b;
+  int c;
+  std::string d;
+  std::vector<int> e;
+  std::vector<std::string> f;
+  Y y;
+};
+
+
+// A simple method name/value data structure
+ template <typename T>
+ struct to {
+   T *pointer;
+   std::string_view m_key;
+   constexpr to(std::string_view const inp_key) noexcept
+       : pointer{}, m_key{} {}
+   constexpr to(std::string_view const inp_key, T &obj_ref) noexcept
+       : pointer{std::addressof(obj_ref)}, m_key{inp_key} {}
+ };
+
+
+// just a bogus concept
+template<typename T>
+concept Keyed = requires(T t) {
+    { t.m_key } -> std::same_as<std::string_view&>;
+    { *t.pointer };
+};
+
+// extract takes instances of the form 'to'.
+template <Keyed ...Funcs>
+bool extract(Funcs&&... endpoints) {
+    ((std::cout << endpoints.m_key << '\n'), ...);
+    return true;
+}
+
+/////////////////////
+// Begin struct_to_tuple
+namespace __impl {
+  template<auto... vals>
+  struct replicator_type {
+    template<typename F>
+      constexpr auto operator>>(F body) const -> decltype(auto) {
+        return body.template operator()<vals...>();
+      }
+  };
+
+  template<auto... vals>
+  replicator_type<vals...> replicator = {};
+}
+
+template<typename R>
+consteval auto expand_all(R range) {
+  std::vector<std::meta::info> args;
+  for (auto r : range) {
+    args.push_back(reflect_value(r));
+  }
+  return substitute(^__impl::replicator, args);
+}
+
+template <typename T>
+constexpr auto struct_to_tuple(T const& t) {
+  return [: expand_all(nonstatic_data_members_of(^T)) :] >> [&]<auto... members>{
+    return std::make_tuple(to(std::meta::identifier_of(members), t.[:members:])...);
+  };
+}
+// End struct_to_tuple
+////////////////////////
+
+int main() {
+  X x;
+  std::apply([](auto&&... xs){ extract(xs...);}, struct_to_tuple(x));
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION

Suppose that you want to do something of the sort...

You have a function (@the-moisrex) that can be called like so...

```c++
extract(to("key1", t.key1), to("key2", t.key2));
```

given...

```c++
struct my_struct {
int key1;
double key2;
}
```

See https://github.com/simdjson/simdjson/pull/2247

Right?

Now can I do it by reflection?


That is. I have `my_struct x` and I want to *automatically*, at compile time, call...


```c++
extract(to("key1", t.key1), to("key2", t.key2));
```

... without having to write `"key1"` and so forth.

See https://github.com/simdjson/experimental_json_builder/issues/29

The answer is positive.

All I need is a helper function which (by reflection) turns any struct into a tuple (`struct_to_tuple`)... that is, something that is effectively capable of the following... 

```c++
std::tuple<to<int>,to<double>> struct_to_tuple(my_struct s);
```
... and then I can call `std::apply`...

```cpp
my_struct x;
std::apply([](auto&&... xs){ extract(xs...);}, struct_to_tuple(x));
```

